### PR TITLE
Support double digital major iOS versions

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -1,4 +1,5 @@
 {
+  "10": "Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1",
   "8": "Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H141 Safari/600.1.4",
   "7": "Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) CriOS/30.0.1599.12 Mobile/11A465 Safari/8536.25",
   "6": "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10B329 Safari/8536.25"

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var parseIntStrict = require('parse-int')
-var REGEX = /OS (\d_\d(_\d)?)/
+var REGEX = /OS (\d\d?_\d(_\d)?)/
 
 module.exports = function iOsVersion (agent) {
   if (!agent) return null

--- a/test.js
+++ b/test.js
@@ -5,6 +5,12 @@ var iOsVersion = require('./')
 var agents = require('./agents.json')
 
 test(function (t) {
+  assert('10', {
+    major: 10,
+    minor: 0,
+    patch: 1
+  })
+
   assert('8', {
     major: 8,
     minor: 4,
@@ -30,4 +36,3 @@ test(function (t) {
     t.deepEquals(iOsVersion(agents[agent]), expected)
   }
 })
-


### PR DESCRIPTION
Adds double digital major version support to iOS10 returns false,
